### PR TITLE
Fix: change file open flag from O_WRONLY to O_RDWR in Group::ReadLock()

### DIFF
--- a/Group.C
+++ b/Group.C
@@ -491,7 +491,7 @@ int Group::ReadLock()
 {
     string lockpath = Dirname();
     lockpath += "/.lock";
-    int fd = open(lockpath.c_str(), O_CREAT|O_WRONLY, 0666);
+    int fd = open(lockpath.c_str(), O_CREAT|O_RDWR, 0666);
     if ( fd < 0 )
     {
         errmsg = lockpath;


### PR DESCRIPTION
Change the `open()` flags parameter in `Group::ReadLock()` from `O_WRONLY` to `O_RDWR`. Calling `flock(fd, LOCK_SH)` on a file descriptor opened with `O_WRONLY` causes failures on some file systems like NFSv4.